### PR TITLE
Add babel-runtime as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "homepage": "https://github.com/umayr/uranus#readme",
   "devDependencies": {
     "babel": "^5.8.23",
-    "babel-runtime": "^5.8.20",
     "eslint": "^1.3.1",
     "mocha": "^2.2.5"
   },
@@ -36,6 +35,7 @@
     "library"
   ],
   "dependencies": {
+    "babel-runtime": "^5.8.20",
     "validator": "^4.0.0"
   }
 }


### PR DESCRIPTION
It breaks after `npm` install.

```
module.js:338
    throw err;
          ^
Error: Cannot find module 'babel-runtime/helpers/interop-require-default'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (D:\Ardina\Ardina\node_modules\uranus\dist\index.js:8:30)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (D:\Ardina\Ardina\src\lib\managers\member.js:10:14)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)

```
